### PR TITLE
Move net connect API call to ntp_client function

### DIFF
--- a/mbed/src/iotc_bsp_io_net.cpp
+++ b/mbed/src/iotc_bsp_io_net.cpp
@@ -71,7 +71,7 @@ iotc_bsp_io_net_state_t iotc_bsp_io_net_socket_connect(
 DISCONNECT:
     delete conn;
     *iotc_socket = 0;
-    
+
     return IOTC_BSP_IO_NET_STATE_ERROR;
 }
 

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -2,44 +2,44 @@
     "name": "google-client",
     "config": {
         "iotc-bsp-debug-log": {
-            "help": "Enable/Disable the bsp debug log, Defaults to 0 logs are disabled.",
+          "help": "Enable/Disable the bsp debug log, Defaults to 0 logs are disabled.",
 	    "value": "0",
-	    "macro_name": "BSP_DEBUG_LOG"            
+	    "macro_name": "BSP_DEBUG_LOG"
         },
 	"iotc-debug-output": {
-            "help": "Enable/Disable the debug log, Defaults to 0 disbaled the logs.",
+          "help": "Enable/Disable the debug log, Defaults to 0 disbaled the logs.",
 	    "value": "0",
-	    "macro_name": "IOTC_DEBUG_OUTPUT"            
+	    "macro_name": "IOTC_DEBUG_OUTPUT"
         },
 	"iotc-debug-printf": {
-            "help": "Sets an alternative to puts for logs output. Especially useful to synchronize output with mbed-trace",
-	    "value": "",
-	    "macro_name": "IOTC_DEBUG_PRINTF"            
+          "help": "Sets an alternative to puts for logs output. Especially useful to synchronize output with mbed-trace",
+	    "value": "printf",
+	    "macro_name": "IOTC_DEBUG_PRINTF"
         },
 	"iotc-mqtt-max-payload-size": {
-            "help": "MQTT maximum payload size, Defaults to (1024 * 128) if undefined.",
+          "help": "MQTT maximum payload size, Defaults to (1024 * 128) if undefined.",
 	    "value": "(1024 * 128)",
-	    "macro_name": "IOTC_MQTT_MAX_PAYLOAD_SIZE"            
+	    "macro_name": "IOTC_MQTT_MAX_PAYLOAD_SIZE"
         },
 	"iotc-default-idle-timeout": {
-            "help": "IOTC default idle timeout, Defaults to 1 if undefined.",
+          "help": "IOTC default idle timeout, Defaults to 1 if undefined.",
 	    "value": "1",
-	    "macro_name": "IOTC_DEFAULT_IDLE_TIMEOUT"            
+	    "macro_name": "IOTC_DEFAULT_IDLE_TIMEOUT"
         },
 	"iotc-max-idle-timeout": {
-            "help": "IOTC maximum idle timeout, Defaults to 5 if undefined.",
+          "help": "IOTC maximum idle timeout, Defaults to 5 if undefined.",
 	    "value": "5",
-	    "macro_name": "IOTC_MAX_IDLE_TIMEOUT"            
+	    "macro_name": "IOTC_MAX_IDLE_TIMEOUT"
         },
 	"iotc-mqtt-port": {
-            "help": "IOTC MQTT port number, Defaults to 8883 if undefined.",
+          "help": "IOTC MQTT port number, Defaults to 8883 if undefined.",
 	    "value": "8883",
-	    "macro_name": "IOTC_MQTT_PORT"            
+	    "macro_name": "IOTC_MQTT_PORT"
         },
 	"iotc-mqtt-host": {
-            "help": "IOTC MQTT host configuration. Defaults to mqtt.2030.ltsapis.goog host and port number 8883 if undefined",
-            "value": "{\"mqtt.2030.ltsapis.goog\", IOTC_MQTT_PORT}",
+          "help": "IOTC MQTT host configuration. Defaults to mqtt.2030.ltsapis.goog host and port number 8883 if undefined",
+          "value": "{\"mqtt.2030.ltsapis.goog\", IOTC_MQTT_PORT}",
 	    "macro_name": "IOTC_MQTT_HOST"
-        }		
+        }
     }
 }


### PR DESCRIPTION
NTP client required the network interface to be connected before requesting the time from NTP server so moved the net connect API call from `iotc_bsp_io_net_socket_connect()` into `mbed-os-example-google-cloud` `ntp_client()` function.