### PR TITLE
Fix the segfault issue

### DIFF
--- a/mbed/src/iotc_bsp_io_net.cpp
+++ b/mbed/src/iotc_bsp_io_net.cpp
@@ -145,7 +145,7 @@ iotc_bsp_io_net_state_t iotc_bsp_io_net_read(iotc_bsp_socket_t iotc_socket,
 iotc_bsp_io_net_state_t iotc_bsp_io_net_close_socket(
     iotc_bsp_socket_t *iotc_socket)
 {
-    if (NULL == *iotc_socket) {
+    if (NULL == iotc_socket || NULL == *iotc_socket) {
         return IOTC_BSP_IO_NET_STATE_ERROR;
     }
 

--- a/mbed/src/iotc_bsp_io_net.cpp
+++ b/mbed/src/iotc_bsp_io_net.cpp
@@ -145,12 +145,12 @@ iotc_bsp_io_net_state_t iotc_bsp_io_net_read(iotc_bsp_socket_t iotc_socket,
 iotc_bsp_io_net_state_t iotc_bsp_io_net_close_socket(
     iotc_bsp_socket_t *iotc_socket)
 {
-    if (NULL == iotc_socket) {
+    if (NULL == *iotc_socket) {
         return IOTC_BSP_IO_NET_STATE_ERROR;
     }
 
-    ((TCPSocket *)iotc_socket)->close();
-    delete ((TCPSocket *)iotc_socket);
+    ((TCPSocket *)(*iotc_socket))->close();
+    delete ((TCPSocket *)(*iotc_socket));
     *iotc_socket = 0;
     return IOTC_BSP_IO_NET_STATE_OK;
 }

--- a/mbed/src/iotc_bsp_io_net.cpp
+++ b/mbed/src/iotc_bsp_io_net.cpp
@@ -33,6 +33,11 @@ iotc_bsp_io_net_state_t iotc_bsp_io_net_socket_connect(
     iotc_bsp_socket_type_t socket_type)
 {
     nsapi_error_t result = NSAPI_ERROR_OK;
+
+    if (NULL == iotc_socket) {
+          return IOTC_BSP_IO_NET_STATE_ERROR;
+    }
+
     auto net = NetworkInterface::get_default_instance();
     MBED_ASSERT(net != nullptr);
     auto conn = new TCPSocket;
@@ -69,7 +74,11 @@ iotc_bsp_io_net_state_t iotc_bsp_io_net_socket_connect(
     return IOTC_BSP_IO_NET_STATE_OK;
 
 DISCONNECT:
-    delete conn;
+    if(conn != nullptr) {
+        conn->close();
+        delete conn;
+    }
+
     *iotc_socket = 0;
 
     return IOTC_BSP_IO_NET_STATE_ERROR;


### PR DESCRIPTION
`typedef intptr_t iotc_bsp_socket_t` is a double pointer data type so deferencing `iotc_socket`  one time before accessing the pointer values in `iotc_bsp_io_net_close_socket` API implementation.

@evedon 